### PR TITLE
swift 3.1 changes

### DIFF
--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -51,7 +51,7 @@ public extension Promise {
         )
     {
         self.init()
-        let bP = basicPromise // fix for EXC_BAD_ACCESS after update to Swift 3.1 (in func fulfullBasic)
+        let bP = basicPromise // fix for EXC_BAD_ACCESS after update to Swift 3.1 (in func fulfillBasic)
         func fulfillBasic(_ r: Result< FulfilledValue >) {
             bP.fulfill(r)
         }

--- a/Sources/Promise.swift
+++ b/Sources/Promise.swift
@@ -51,8 +51,9 @@ public extension Promise {
         )
     {
         self.init()
+        let bP = basicPromise // fix for EXC_BAD_ACCESS after update to Swift 3.1 (in func fulfullBasic)
         func fulfillBasic(_ r: Result< FulfilledValue >) {
-            basicPromise.fulfill(r)
+            bP.fulfill(r)
         }
         do {
             try resolvers(


### PR DESCRIPTION
After the update to Swift 3.1 I stumbled upon an EXC_BAD_ACCESS in the init call of the Promise extension. This minor change fixes the bug for me.